### PR TITLE
Grammar & Semantic fixes

### DIFF
--- a/src/htmlvalidator.js
+++ b/src/htmlvalidator.js
@@ -148,7 +148,7 @@ var validateHtml = function ($) {
     /**
      *  RULE 3 - obsolete elements
      *  Reference https://www.w3.org/TR/html51/obsolete.html#non-conforming-features
-     *  @todo - all obsolete elements should be added to obsoleteTags array below.
+     *  TODO: all obsolete elements should be added to obsoleteTags array below.
      *
      */
     var obsoleteTags = [
@@ -220,7 +220,7 @@ var validateHtml = function ($) {
     /**
     *  RULE 4 - obsolete attributes
     *  Reference  https://w3c.github.io/html/obsolete.html#element-attrdef-a-charset
-    *  @todo - all other obsolete attributes to obsoleteAttributes array
+    *  TODO: all other obsolete attributes to obsoleteAttributes array
     *
     * */
 

--- a/src/htmlvalidator.js
+++ b/src/htmlvalidator.js
@@ -15,13 +15,13 @@ var totalHtmlSuggestions = 0;
 
 var setGlobals = function (options) {
     globalOptions = options;
-}
+};
 
 var validateHtml = function ($) {
     var totalProblems = 0;
     var totalSuggestions = 0;
 
-    console.log(chalk.yellow(figures.pointer) + chalk.rgb(200,200,200)(' Checking HTML guidelines..\n'));
+    console.log(chalk.yellow(figures.pointer) + chalk.rgb(200,200,200)(' Checking HTML guidelines...\n'));
 
     /*
     *  References
@@ -35,34 +35,34 @@ var validateHtml = function ($) {
     *
     * */
     if($.html().search('<!DOCTYPE') != 0){
-        alerts.alertWarning('The doctype is required just above the <html> tag, at the very start of each document you write.');
+        alerts.alertWarning('Doctype declaration is required above the <html> tag, at the very start of each document you write.');
         totalProblems++;
     }
 
     var requiredTags = [
         {
             tag : 'html',
-            error : '<html> tag should be appeared just after the doctype declaration',
+            error : '<html> tag should appear directly after doctype declaration.',
             root : null,
             rootError : null
         },
         {
             tag : 'head',
-            error : '<head> tag should be appeared',
+            error : '<head> tag should have appeared.',
             root : 'html',
-            rootError : '<head> should be added inside <html>'
+            rootError : '<head> tag should be added inside <html> tag.'
         },
         {
             tag : 'title',
-            error : '<title> tag should be appeared in order to display the title of document',
+            error : '<title> tag should have appeared in order to display the title of the document.',
             root : 'head',
-            rootError : '<title> should be added inside <head>'
+            rootError : '<title> tag should be added inside <head> tag.'
         },
         {
             tag : 'body',
-            error : 'The content of web page should be wrapped with <body> tag',
+            error : 'The content of the web page should be wrapped by (inside) <body> tag.',
             root : 'html',
-            rootError : '<body> should be added inside <html>'
+            rootError : '<body> tag should be added inside <html> tag.'
         },
     ];
 
@@ -98,13 +98,12 @@ var validateHtml = function ($) {
         {
             tag : 'img',
             attribute : 'alt',
-            error : 'Make sure to offer alternative access. For images that means use of meaningful alternative text',
+            error : 'Make sure to offer alternative access. For images this means use of meaningful alternative text.',
             level : 1,
             showEmptySuggestion : true,
-            emptySuggestion : 'Make sure to offer alternative access. For images that means use of meaningful alternative text'
-        }
+            emptySuggestion : 'Make sure to offer alternative access. For images this means use of meaningful alternative text.'
+        },
     ];
-
 
     for(var requiredAttributesIndex in requiredAttribs){
         var requiredAttribute = requiredAttribs[requiredAttributesIndex];
@@ -149,62 +148,63 @@ var validateHtml = function ($) {
     /*
      *  RULE 3 - obsolete elements
      *  Reference https://www.w3.org/TR/html51/obsolete.html#non-conforming-features
-     *  TODO - all obsolete elements should be added to obsoleteTags array below.
+     *  @TODO - all obsolete elements should be added to obsoleteTags array below.
      *
      */
     var obsoleteTags = [
         {
             tag : 'applet',
-            error : '<applet> is entirely obsolete, and must not be used by authors.',
-            solution : 'Use <embed> or <object> instead'
+            error : '<applet> is completely obsolete, and must not be used by authors.',
+            solution : 'Use <embed> or <object> instead.'
         },
         {
             tag : 'acronym',
-            error : '<acronym> is entirely obsolete, and must not be used by authors.',
+            error : '<acronym> is completely obsolete, and must not be used by authors.',
             solution : 'Use <abbr> instead.'
         },
         {
             tag : 'bgsound',
-            error : '<bgsound> is entirely obsolete, and must not be used by authors.',
+            error : '<bgsound> is completely obsolete, and must not be used by authors.',
             solution : 'Use <audio> instead.'
         },
         {
             tag : 'dir',
-            error : '<dir> is entirely obsolete, and must not be used by authors.',
+            error : '<dir> is completely obsolete, and must not be used by authors.',
             solution : 'Use <ul> instead.'
         },
         {
             tag : 'frame',
-            error : '<frame> is entirely obsolete, and must not be used by authors.',
-            solution : 'Either use <iframe> and CSS instead, or use server-side includes to generate complete pages with the various invariant parts merged in.'
+            error : '<frame> is completely obsolete, and must not be used by authors.',
+            solution : 'Use either <iframe> with CSS, or render invariant parts into the page server-side, generating complete pages with said parts merged.'
         },
         {
             tag : 'frameset',
-            error : '<frameset> is entirely obsolete, and must not be used by authors.',
-            solution : 'Either use <iframe> and CSS instead, or use server-side includes to generate complete pages with the various invariant parts merged in.'
+            error : '<frameset> is completely obsolete, and must not be used by authors.',
+            solution : 'Use either <iframe> with CSS, or render invariant parts into the page server-side, generating complete pages with said parts merged.'
         },
         {
             tag : 'noframes',
-            error : '<noframes> is entirely obsolete, and must not be used by authors.',
-            solution : 'Either use <iframe> and CSS instead, or use server-side includes to generate complete pages with the various invariant parts merged in.'
+            error : '<noframes> is completely obsolete, and must not be used by authors.',
+            solution : 'Use either <iframe> with CSS, or render invariant parts into the page server-side, generating complete pages with said parts merged.'
         },
         {
             tag : 'hgroup',
-            error : '<hgroup> is entirely obsolete, and must not be used by authors.',
-            solution : 'To mark up subheadings, consider putting the subheading into a p element after the h1-h6 element containing the main heading, or putting the subheading directly within the h1-h6 element containing the main heading, but separated from the main heading by punctuation and/or within, for example, a span class="subheading" element with differentiated styling.\n' +
-            'Headings and subheadings, alternative titles, or taglines can be grouped using the header or div elements.'
+            error : '<hgroup> is completely obsolete, and must not be used by authors.',
+            solution : 'To mark up subheadings, consider putting the subheading in a <p> after the <h1>...<h6> containing the main heading, or putting the subheading directly in the <h1>...<h6> containing the main heading, but separated from the main heading by punctuation and/or within, for example, a <span class="subheading"> to apply differentiated styling (to .subheading class).\n' +
+            'Headings and subheadings, alternative titles, or taglines can be grouped using the <header> or <div>.'
         },
         {
             tag : 'isindex',
-            error : '<isindex> is entirely obsolete, and must not be used by authors.',
-            solution : 'Use an explicit form and text field combination instead.'
+            error : '<isindex> is completely obsolete, and must not be used by authors.',
+            solution : 'Use an explicit <form> and <input type="text"> (text field) combination instead.'
         },
         {
             tag : 'listing',
-            error : '<listing> is entirely obsolete, and must not be used by authors.',
-            solution : 'Use pre and code instead.'
-        }
+            error : '<listing> is completely obsolete, and must not be used by authors.',
+            solution : 'Use <pre> and <code> instead.'
+        },
     ];
+    
     for(var obsoleteTagIndex  in obsoleteTags){
         var obsoleteTag = obsoleteTags[obsoleteTagIndex];
         var obsoleteTagDom = $(obsoleteTag.tag);
@@ -220,7 +220,7 @@ var validateHtml = function ($) {
     /*
     *  RULE 4 - obsolete attributes
     *  Reference  https://w3c.github.io/html/obsolete.html#element-attrdef-a-charset
-    *  TODO - all other obsolete attributes to obsoleteAttributes array
+    *  @TODO - all other obsolete attributes to obsoleteAttributes array
     * */
 
 
@@ -228,64 +228,64 @@ var validateHtml = function ($) {
         {
             tags : 'a,link',
             attribute : 'charset',
-            error : 'charset attribute in <link>,<a> is entirely obsolete, and must not be used by authors',
-            solution : 'Use an HTTP Content-Type header on the linked resource instead.'
+            error : 'charset attribute on <link> and <a> is completely obsolete, and must not be used by authors.',
+            solution : 'Use a HTTP Content-Type header on the linked resource instead.'
         },
         {
             tags : 'a',
             attribute : 'coords',
-            error : 'coords attribute in <a> is entirely obsolete, and must not be used by authors',
-            solution : 'Use area instead of a for image maps.'
+            error : 'coords attribute on <a> is completely obsolete, and must not be used by authors.',
+            solution : 'Use <area> instead of <a> for image maps.'
         },
         {
             tags : 'a',
             attribute : 'shape',
-            error : 'shape attribute in <a> is entirely obsolete, and must not be used by authors',
-            solution : 'Use area instead of a for image maps.'
+            error : 'shape attribute on <a> is completely obsolete, and must not be used by authors.',
+            solution : 'Use <area> instead of <a> for image maps.'
         },
         {
             tags : 'a,link',
             attribute : 'methods',
-            error : 'methods attribute in <link>,<a> is entirely obsolete, and must not be used by authors',
+            error : 'methods attribute on <link> and <a> is completely obsolete, and must not be used by authors.',
             solution : 'Use the HTTP OPTIONS feature instead.'
         },
         {
             tags : 'a,embed,img,option',
             attribute : 'name',
-            error : 'name attribute in <a>,<embed>,<img>,<option> is entirely obsolete, and must not be used by authors',
+            error : 'name attribute on <a>, <embed>, <img> and <option> is completely obsolete, and must not be used by authors.',
             solution : 'Use the id attribute instead.'
         },
         {
             tags : 'a,link',
             attribute : 'urn',
-            error : 'urn attribute in <link>,<a> is entirely obsolete, and must not be used by authors',
+            error : 'urn attribute on <link> and <a> is completely obsolete, and must not be used by authors.',
             solution : 'Specify the preferred persistent identifier using the href attribute instead.'
         },
         {
             tags : 'form',
             attribute : 'accept',
-            error : 'accept attribute in <form> is entirely obsolete, and must not be used by authors',
-            solution : 'Use the accept attribute directly on the input elements instead.'
+            error : 'accept attribute on <form> is completely obsolete, and must not be used by authors.',
+            solution : 'Use the accept attribute directly on the <input> instead.'
         },
         {
             tags : 'area',
             attribute : 'nohref',
-            error : 'nohref attribute in <area> is entirely obsolete, and must not be used by authors',
-            solution : 'Omitting the href attribute is sufficient; the nohref attribute is unnecessary. Omit it altogether.'
+            error : 'nohref attribute on <area> is completely obsolete, and must not be used by authors.',
+            solution : 'Omitting the href attribute is sufficient as is not necessary (Omit it altogether).'
         },
         {
             tags : 'head',
             attribute : 'profile',
-            error : 'profile attribute in <head> is entirely obsolete, and must not be used by authors',
-            solution : 'When used for declaring which meta terms are used in the document, unnecessary; omit it altogether, and register the names.\n' +
-            'When used for triggering specific user agent behaviors: use a link element instead.'
+            error : 'profile attribute on <head> is completely obsolete, and must not be used by authors.',
+            solution : 'When used for declaring which meta terms are used in the document it is not necessary (omit it altogether), and register the names.\n' +
+            'When used for triggering specific user agent behaviors use <link> (element) instead.'
         },
         {
             tags : 'h1,h2,h3,h4,h5,h6',
             attribute : 'align',
-            error : 'align attribute in <h1>..<h6> is entirely obsolete, and must not be used by authors',
-            solution : 'use CSS instead.'
-        }
+            error : 'align attribute in <h1>...<h6> is completely obsolete, and must not be used by authors.',
+            solution : 'Use CSS instead.'
+        },
     ];
 
     for(var obsoleteAttributesIndex in obsoleteAttributes){
@@ -299,13 +299,12 @@ var validateHtml = function ($) {
                 totalProblems++;
             }
         }
-
     }
 
 
     console.log();
     console.log('HTML SUMMARY');
-    if(totalProblems == 0 ){
+    if(totalProblems == 0){
         console.log(chalk.rgb(0,200,0)(figures.tick) + ' no problem found');
     }
     else {

--- a/src/htmlvalidator.js
+++ b/src/htmlvalidator.js
@@ -145,10 +145,10 @@ var validateHtml = function ($) {
 
 
 
-    /*
+    /**
      *  RULE 3 - obsolete elements
      *  Reference https://www.w3.org/TR/html51/obsolete.html#non-conforming-features
-     *  @TODO - all obsolete elements should be added to obsoleteTags array below.
+     *  @todo - all obsolete elements should be added to obsoleteTags array below.
      *
      */
     var obsoleteTags = [
@@ -217,10 +217,11 @@ var validateHtml = function ($) {
     }
 
 
-    /*
+    /**
     *  RULE 4 - obsolete attributes
     *  Reference  https://w3c.github.io/html/obsolete.html#element-attrdef-a-charset
-    *  @TODO - all other obsolete attributes to obsoleteAttributes array
+    *  @todo - all other obsolete attributes to obsoleteAttributes array
+    *
     * */
 
 

--- a/src/links.js
+++ b/src/links.js
@@ -28,7 +28,7 @@ var linkChecker = function ($, rootUrl) {
 
     var urls = [];
     if(links.length == 0){
-        /** @todo ? */
+        /** TODO: ? */
     }
     else {
         console.log(chalk.italic('Adding ' + links.length + ' link(s) to the queue...\n'));

--- a/src/links.js
+++ b/src/links.js
@@ -12,13 +12,13 @@ var globalOptions = {
 var isLocal = function (link) {
     var urlinfo = url.parse(link);
     var host = urlinfo.host;
-    return (host == globalOptions.localHost || host==null);
+    return (host == globalOptions.localHost || host == null);
 };
 
 
 var setGlobals = function (options) {
     globalOptions = options;
-}
+};
 
 
 var linkChecker = function ($, rootUrl) {
@@ -28,10 +28,10 @@ var linkChecker = function ($, rootUrl) {
 
     var urls = [];
     if(links.length == 0){
-
+        // @TODO
     }
     else {
-        console.log(chalk.italic('Adding ' + links.length+ ' link(s) to the queue...\n'));
+        console.log(chalk.italic('Adding ' + links.length + ' link(s) to the queue...\n'));
         for (var i = 0; i < links.length; i++) {
             var innerLink = $(links[i]).attr('href');
             if (typeof innerLink != 'undefined') {
@@ -48,7 +48,7 @@ var linkChecker = function ($, rootUrl) {
                 }
                 else {
                     if(globalOptions.verbose)
-                        console.log('EXT  ' +  chalk.grey(innerLink));
+                        console.log('EXT  ' + chalk.grey(innerLink));
                 }
 
                 try {

--- a/src/links.js
+++ b/src/links.js
@@ -28,7 +28,7 @@ var linkChecker = function ($, rootUrl) {
 
     var urls = [];
     if(links.length == 0){
-        // @TODO
+        /** @todo ? */
     }
     else {
         console.log(chalk.italic('Adding ' + links.length + ' link(s) to the queue...\n'));

--- a/src/w3clink.js
+++ b/src/w3clink.js
@@ -34,12 +34,12 @@ var isLocal = function (link) {
 
 var isHtmlResponse  = function(header){
     return (header['content-type'].search('text/html') != -1);
-}
+};
 
 
 var execute = function () {
     runValidator(urlQueue[0]);
-}
+};
 
 
 var initValidator = function (options) {
@@ -141,7 +141,7 @@ var displaySummary = function () {
     console.log((validationResult.problems == 0 ? chalk.rgb(0,200,0)(figures.tick) :  chalk.rgb(200,0,0)(figures.cross))   + ' HTML Problems      : ' + validationResult.problems);
     if(globalOptions.verbose)
         console.log((validationResult.suggestions == 0 ? chalk.rgb(200,200,0)(figures.info) :  chalk.rgb(200,200,0)(figures.info))   + ' HTML Suggestions   : ' + validationResult.suggestions);
-}
+};
 
 module.exports.init = initValidator;
 module.exports.run = runValidator;


### PR DESCRIPTION
Fixed:

- Grammar (I know some is from mozilla, but still refined in places)
- Reworked `frame`, `frameset` and `noframes` solution (`obsoleteTags`)
- Semantic (semicolons, spacing etc.)
- ~~Todo's turned into JSDoc style (`/** */` and `@todo`) (get highlighted in most modern editors)~~
- Todo changed to simpler flag `TODO`. (use `NOTE`, `REVIEW`, `HACK` etc. in the future where necessary)
- Other misc.