### PR TITLE
Contribution Guideline and Issue Template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,34 @@
+<!--
+Before you submit this issue, make sure you have tried searching through the exisiting issues (open and closed) to see if your issue has already been posted.
+
+Have you read our Code of Conduct? By filing an issue you comply with it, so it'd be best to give it a read: 
+-->
+
+- [ ] I have tried looking for similar issues and I am sure this is a new issue.
+<!-- Place an x in the box if you have -->
+
+### Description
+[Consise description of issue]
+
+### Steps to Reproduce
+1. [Step One]
+2. [Step Two]
+3. [and so on...]
+
+**Expected behavior**: [What you expect to happen]
+
+**Actual behavior**: [What actually happens]
+
+**Reproduces how often**: [What percerage of the time does it reproduce?]
+
+### Versions
+_Please include package version (in `package.json`), npm version (`npm -v`), node version (`node -v`), OS and any other relevant software versions_
+
+**Package**: [0.0.0]
+
+**npm**: [0.0.0]
+
+**node**: [0.0.0]
+
+### Additional Information
+[Any other infomation, configuration or data that might be necessary to reproduce this issue.]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to w3c-link-validator
+<!-- TODO: Add introduction -->
+:tada: Great to see your interested in contributing! :tada:
+
+The following guidelines are set out for contributing to w3c-link-validator, please read through carefully 
+
+
+## Table of Contents
+
+[Code of Conduct](#code-of-conduct)
+
+[Getting Started](#getting-started)
+- [How it works (crawling algorithm)](#how-it-works-crawling-algorithm)
+- [Development Setup](#development-setup)
+
+[Found a bug?](#found-a-bug)
+
+[Submitting an Issue](#submitting-an-issue)
+- [Reporting Bugs](#reporting-bugs)
+- [Suggesting Ehancements](#suggesting-enhancements)
+- [Code Contribution](#code-contribution)
+    - [Beginner Issues](#beginner-issues)
+
+[Styleguides](#styleguides)
+- [Git Commit Message](#git-commit-messages)
+- [JavaScript Styleguide](#javascript-styleguide)
+- [Ruleset Styleguide](#ruleset-styleguide)
+
+[Attributions](#attributions)
+
+[License](#license)
+
+
+## Code of Conduct
+This project and everyone participating in it is govered by our [Code of Conduct](https://github.com/99xt/w3c-link-validator/blob/master/CODE_OF_CONDUCT.md). By participating, you are expected to upload this code. Please report unacceptable behavior to [99xt@googlegroups.com](mailto:99xt@googlegroups.com).
+
+
+## Getting Started
+<!-- TODO: Add "Getting Started" section --> 
+> Coming soon
+
+
+### How it works (crawling algorithm)
+![Crawling algorithm flowchart](media/crawlingalgofc.png "Crawling algorithm flowchart")
+
+### Development Setup
+Fork and clone repo 
+
+```bash
+$ git clone https://github.com/<username>/w3c-link-validator.git
+```
+
+Install dependencies
+
+```bash
+$ npm install
+```
+
+Link to global commands
+
+```bash
+$ npm link
+```
+
+Run the tests
+
+```bash
+$ npm run test
+```
+
+Check the code coverage with [istanbul](https://istanbul.js.org/). HTML report will be generated to `/coverage/lcov-report`
+
+```bash
+$ npm run coverage
+```
+
+
+## Found a bug?
+**Ensure the bug has not already been reported** by searching on GitHub under [Issues](https://github.com/99xt/w3c-link-validator/issues)
+
+**Unable to find a issue addressing the problem?** [Open a new one](https://github.com/99xt/w3c-link-validator/issues/new) and follow steps below and template provided.
+
+
+## Submitting an Issue
+<!-- TODO: Add "Submitting an Issue" section --> 
+> Coming Soon
+
+### Reporting Bugs :space_invader:
+<!-- TODO: Add "Reporting Bugs" section --> 
+> Coming Soon
+
+### Suggesting Enhancements :bulb:
+<!-- TODO: Add "Suggesting Enhancements" section --> 
+> Coming Soon
+
+### Code Contribution
+<!-- TODO: Add "Code Contribution" section --> 
+> Coming Soon
+
+#### Beginner Issues
+<!-- TODO: Add "Beginner Issues" section --> 
+> Coming Soon
+
+
+## Attributions
+These contribution guidelines have been adapted from the [Atom editor contribution guidelines](https://github.com/atom/atom/blob/master/CONTRIBUTING.md).
+
+## License
+MIT © [99XT](https://github.com/99xt)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Massive websites may log bunch of messages to your terminal. Therefore you may s
 
 
 ## Contributing
+[**Click here to view the full contribution guidelines**](CONTRIBUTING.md)
 
 #### Development setup
 


### PR DESCRIPTION
Added:

- More detailed contribution guidelines `CONTRIBUTING.md` (still has things to add)
- General sections to `CONTRIBUTING.md` (general sections as guide/template for you to add what you want with, nothing special just generic stuff)
- Moved contribution info from `README.md` to `CONTRIBUTING.md`

Again, this isn't set in stone, just a bounce board to creating complete `CONTRIBUTING.md`.

_Closes #51_