### PR TITLE
Removed Temporary notice from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ $ npm install w3c-link-validator -g
 
 After installation `w3clink` command will be available globally.
 
-_Note :  'w3c-link-validator' is not in the npm registry yet. Therefore kindly follow [developers installation](#contributing)._
-
 
 ## Tutorial
 


### PR DESCRIPTION
Package is now at [npmjs](https://www.npmjs.com/package/w3c-link-validator)